### PR TITLE
Update wedding schedule to include Monday June 16th

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md - Guidelines for Okaziya Wedding Project
+
+## Commands
+
+- `npm run dev` - Start development server
+- `npm run build` - Build for production
+- `npm run build:dev` - Build for development
+- `npm run lint` - Run ESLint
+- `npm run format` - Format code with Prettier
+- `npm run preview` - Preview production build
+
+## Code Style
+
+- **TypeScript**: Use TS for type safety (strict mode disabled)
+- **Imports**: Use absolute imports with `@/*` alias for src directory
+- **Components**: Follow React functional component pattern with hooks
+- **CSS**: Use Tailwind CSS for styling
+- **Formatting**: Follow Prettier defaults (no custom config found)
+- **Error Handling**: Use try/catch for async operations
+- **Naming**: PascalCase for components, camelCase for variables/functions
+- **UI Components**: Use shadcn/ui component system with Radix UI primitives
+- **State Management**: React hooks for local state, no global state library

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -32,16 +32,26 @@ const Schedule = () => {
         { time: "08:00–09:00", description: "Common breakfast in the Stugbyn conference room" },
         { time: "09:30–10:30", description: "Guided circle training at Roddens Hus (bring gym clothes!)" },
         {
-          time: "10:30–11:30",
-          description: "Accommodation check-out for participants staying in the Siljansnäs Stugby cottages",
-        },
-        {
           time: "12:00–13:00",
           description: "Lunch at Roddens Hus (outdoorsy casual clothes, it can rain out on the sea)",
         },
         {
-          time: "13:00–16:00",
+          time: "13:00–15:00",
           description: "Presentation about the local church boats followed by rowing on the Siljan sea",
+        },
+        {
+          time: "15:00–15:30",
+          description: "Farewell fika at Roddens Hus, weekend ended!",
+        },
+      ],
+    },
+    {
+      date: "Monday, June 16th",
+      events: [
+        { time: "08:00–09:00", description: "Optional breakfast in the conference room" },
+        {
+          time: "09:30–10:30",
+          description: "Check-out for participants staying in the Siljansnäs Stugby cottages",
         },
       ],
     },


### PR DESCRIPTION
Changes:
- Added Monday June 16th with breakfast and check-out
- Moved check-out from Sunday to Monday
- Shortened church boat event on Sunday to end at 3pm
- Added farewell fika on Sunday
- Added CLAUDE.md with build/lint commands and code style guidelines for agentic coding assistants

Resolves okaziya/wedding#56

🤖 Generated with [Claude Code](https://claude.ai/code)


## Testing

Proof that it works: https://mblomdahl.github.io/wedding/schedule/